### PR TITLE
Added url to src of script tag

### DIFF
--- a/resources/views/errorPage.php
+++ b/resources/views/errorPage.php
@@ -22,7 +22,7 @@
 
     <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.7.0/css/all.css">
 
-    <script src="/<?=$housekeepingEndpoint?>/assets"></script>
+    <script src="<?= env('APP_URL') ?>/<?=$housekeepingEndpoint?>/assets"></script>
 </head>
 <body class="scrollbar-lg">
 


### PR DESCRIPTION
This modification is backwards compatible, and this setting allows the component to be used by those not using the built-in php server, such as XAMPP.
The project url in XAMPP is something like http://localhost/laravel-instalation/public, so the path / <?= $ housekeepingEndpoint ?>/assets does not understand this component.